### PR TITLE
Convert flair ID to integer, fixes #17

### DIFF
--- a/web/js/init.js
+++ b/web/js/init.js
@@ -2053,7 +2053,7 @@ $(function(){
 
 	var t = getStorage('myFlairID');
 	if(t != null) {
-		MY_FLAIR_ID = parseInt(t);
+		MY_FLAIR_ID = parseInt(t, 10);
 		$("#flairMenu").addClass("flair_"+MY_FLAIR_ID);
 	}
 

--- a/web/js/init.js
+++ b/web/js/init.js
@@ -2053,7 +2053,7 @@ $(function(){
 
 	var t = getStorage('myFlairID');
 	if(t != null) {
-		MY_FLAIR_ID = t;
+		MY_FLAIR_ID = parseInt(t);
 		$("#flairMenu").addClass("flair_"+MY_FLAIR_ID);
 	}
 


### PR DESCRIPTION
Keep flair ID as a number, not a possible string. I assume this would remove the need for checking for id type in server, but keeping that as a possibility for now.