### PR TITLE
Get current time if message has no timestamp defined

### DIFF
--- a/web/js/functions.js
+++ b/web/js/functions.js
@@ -1341,7 +1341,7 @@ function addChatMsg(data,_to) {
 
 		$(to).children().slice(0, -500).remove();
 
-		var d = new Date(data.msg.timestamp);
+		var d = new Date(data.msg.timestamp || Date.now());
 		if ($(`li.${nick}`).length != 0) {
 			CHATLIST[nick] = d.getTime();
 		}


### PR DESCRIPTION
Fixes NaN in the "you got berry" messages and prevents from messages that don't specify a timestamp form appearing as NaN