### PR TITLE
Prevent messages from users with invalid type or without a nick

### DIFF
--- a/docker/node/server.js
+++ b/docker/node/server.js
@@ -2309,6 +2309,8 @@ io.sockets.on('connection', function (ioSocket) {
 
 		if (typeof (data) !== "object" || typeof (data.msg) !== "string") { throw kick("Expected data"); }
 
+		if (type < userTypes.ANONYMOUS || nick === '[no username]') { throw kick("Sending messages straight to socket"); }
+
 		const { metadata: metaAttempt, msg } = data;
 		if (msg.length > SERVER.settings.core.max_chat_size) { throw kick(`Message length exeeds max size of ${SERVER.settings.core.max_chat_size}`); }
 

--- a/web/js/functions.js
+++ b/web/js/functions.js
@@ -2089,7 +2089,7 @@ function canClosePoll() {
 	return canCreatePoll();
 }
 function canChat() {
-	return NAME;
+	return NAME && TYPE >= -1;
 }
 function canMoveBerry() {
 	if (TYPE >= 1) {


### PR DESCRIPTION
Users are not supposed to send messages to server if they don't have a type or somehow have acquired a '[no username]' as their username, possibly due to sending events manually to socket. Added a check to server and client to prevent it.