### PR TITLE
Prevent errors in YT's getVolume() when API is not ready

### DIFF
--- a/web/js/player.js
+++ b/web/js/player.js
@@ -203,11 +203,11 @@ window.PLAYERS.yt = {
 
         //only grab volumes if youtube's api is ready, 
         //otherwise default to current volume
-        if (this.PLAYER.getVolume) {
+        if (this.PLAYER && this.PLAYER.getVolume) {
             volume = this.PLAYER.getVolume();
         }
 
-        if (this.PLAYER.isMuted) {
+        if (this.PLAYER && this.PLAYER.isMuted) {
     		volume = this.PLAYER.isMuted() ? 0 : volume;
         }
 

--- a/web/js/player.js
+++ b/web/js/player.js
@@ -199,7 +199,12 @@ window.PLAYERS.yt = {
         }
     },
 	getVolume: function(callback){
-        let volume = this.PLAYER.getVolume();
+        let volume = window.volume.get('yt');
+
+        //only get volume from player when method exists 
+        if (this.PLAYER.getVolume) {
+            volume = this.PLAYER.getVolume();
+        }
 
         if (this.PLAYER.isMuted()) {
     		volume = 0;

--- a/web/js/player.js
+++ b/web/js/player.js
@@ -201,13 +201,14 @@ window.PLAYERS.yt = {
 	getVolume: function(callback){
         let volume = window.volume.get('yt');
 
-        //only get volume from player when method exists 
+        //only grab volumes if youtube's api is ready, 
+        //otherwise default to current volume
         if (this.PLAYER.getVolume) {
             volume = this.PLAYER.getVolume();
         }
 
-        if (this.PLAYER.isMuted()) {
-    		volume = 0;
+        if (this.PLAYER.isMuted) {
+    		volume = this.PLAYER.isMuted() ? 0 : volume;
         }
 
 		if(callback)callback(volume);


### PR DESCRIPTION
Default to volume manager's volume instead if API is not ready.