### PR TITLE
Add age checks when attempting to queue youtube videos

### DIFF
--- a/docker/node/server.js
+++ b/docker/node/server.js
@@ -1637,9 +1637,22 @@ function addVideoYT(socket, data, meta, successCallback, failureCallback) {
 				}
 			}
 
-			for (var hasProperties in restrictReasons) { break; }
-			if (hasProperties) {
+			const ageChecks = {
+				adults: vidObj.contentDetails.contentRating.ytRating === 'ytAgeRestricted',
+				kids: vidObj.status.madeForKids || vidObj.status.selfDeclaredMadeForKids || false
+			};
+
+			//check for the age restrictions
+			if (!data.force && (ageChecks.adults || ageChecks.kids)) {
+				restrictReasons.ageRestrictions = ageChecks;
+				maybeError = 'video is possibly age restricted';
+			}
+
+			if (!data.force && restrictReasons.countries) {
 				resolveRestrictCountries(restrictReasons);
+			}
+
+			if (!data.force && Object.keys(restrictReasons).length > 0) {
 				socket.emit("videoRestriction", restrictReasons);
 			}
 

--- a/web/js/callbacks.js
+++ b/web/js/callbacks.js
@@ -565,7 +565,7 @@ socket.on('searchHistoryResults', function (data) {
 	realignPosHelper();
 });
 socket.on('videoRestriction', function (data) {
-	showVideoRestrictionDialog(data.restricted, data.noembed, data.countryNames || data.countries, data.totalCountries);
+	showVideoRestrictionDialog(data);
 });
 socket.on('doorStuck', function () {
 	// DOOR STUCK, DOOR STUCK

--- a/web/js/functions.js
+++ b/web/js/functions.js
@@ -690,9 +690,6 @@ function showVideoRestrictionDialog(data) {
 		case 'geoblock': {
 			let countryText;
 
-			console.log(data.countryNames);
-			console.log(data.countries);
-
 			const countries = data.countryNames || data.countries;
 			const totalCountries = data.totalCountries;
 

--- a/web/js/functions.js
+++ b/web/js/functions.js
@@ -689,6 +689,13 @@ function showVideoRestrictionDialog(data) {
 		}
 		case 'geoblock': {
 			let countryText;
+
+			console.log(data.countryNames);
+			console.log(data.countries);
+
+			const countries = data.countryNames || data.countries;
+			const totalCountries = data.totalCountries;
+
 			if (Array.isArray(countries)) {
 				countryText = countries.join(', ');
 				if (totalCountries > countries.length) {


### PR DESCRIPTION
Keeping as draft for now
**Changes**
- Rewrote the logic on restriction dialog to remove duplicate code. 
- Restriction dialog now shows all possible reasons why video cannot be played
- Added checks for age restricted and "for kids" videos

**Notes**

- Unfortunately the checks for the "can only be played on youtube.com" aka syndicated videos are not possible without utilising rather expensive (100 vs 1 units) query calls to Youtube's search API endpoint. 
- There is currently no distinction between whitelisted and blacklisted countries, which leads to situations where only few countries are shown as blocked, despite majority of the countries are blocked.
