### PR TITLE
Update video.js to latest release, fix spacebar not working

### DIFF
--- a/web/headers.php
+++ b/web/headers.php
@@ -58,7 +58,7 @@
 
 <?php start_minified_tags(); ?>
 
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/video.js/7.3.0/video-js.min.css" integrity="sha256-mujqz1jG8djcBxoJnvfvTIjRxz7y5xNpzY18x8au5ck=" crossorigin="anonymous" />
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/video.js/7.15.4/video-js.min.css" integrity="sha512-RU6FIpN8MZ6jrswHMYzP9t7QlAtDkpCJP6uqyHYm56iP6eEdYCDfMW2C42KtimtJ8DKa+iWJqjpeTyLyQjV61g==" crossorigin="anonymous" referrerpolicy="no-referrer" />
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/jqueryui/1.12.1/themes/ui-lightness/jquery-ui.min.css" integrity="sha256-N7K28w/GcZ69NlFwqiKb1d5YXy37TSfgduj5gQ6x8m0=" crossorigin="anonymous" />
 <link rel="stylesheet" href="<?= cdn('vendor/videojs-quality-selector/quality-selector.css') ?>" />
 
@@ -96,7 +96,7 @@ if (date('n') == 6 && $_COOKIE['no-pride'] !== 'true') {
 <script src="https://cdnjs.cloudflare.com/ajax/libs/jqueryui/1.12.1/jquery-ui.min.js" integrity="sha256-KM512VNnjElC30ehFwehXjx1YCHPiQkOPmqnrWtpccM=" crossorigin="anonymous" defer></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/tinyscrollbar/2.4.2/jquery.tinyscrollbar.min.js" integrity="sha256-gENsdwXJl1qiwOqS0DF+kfqTP5Dy+0gDTtxpRcWVhrU=" crossorigin="anonymous" defer></script>
 
-<script src="https://cdnjs.cloudflare.com/ajax/libs/video.js/7.14.3/video.min.js" integrity="sha512-kNY62HZwz6DRXwF3PP9ltv2db/E+pC9VA8CdDuABXycPlb0IxhOyUprvdkx6cKdKeG5nf+rP7t2XW7unXig6JQ==" crossorigin="anonymous" referrerpolicy="no-referrer" defer></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/video.js/7.15.4/video.min.js" integrity="sha512-dsg6qxwnVPFvhJhbRxyhW9gFvzytQ//4fCinJgKZQuoH6v6JYryP4OOjDGY7MfdVHjv1trJRDmJWdL2dNsbm6A==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/videojs-flash/2.1.2/videojs-flash.min.js" integrity="sha256-2sKPIPOV8Cj34r74ZnRcdKrQ7Jqqg0o1zR2c74VDW1s=" crossorigin="anonymous" defer></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/dashjs/2.9.2/dash.all.min.js" integrity="sha256-EmXFhpSryXnCa3tOiKDfYUFhpmnkvo3PSe3Tj3KpX6o=" crossorigin="anonymous" defer></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/videojs-contrib-dash/2.10.0/videojs-dash.min.js" integrity="sha256-xhLRr5mlvCCC7DndQjNURZOXGxwYUoB2VoF0mNUiuJc=" crossorigin="anonymous" defer></script>

--- a/web/headers.php
+++ b/web/headers.php
@@ -96,7 +96,7 @@ if (date('n') == 6 && $_COOKIE['no-pride'] !== 'true') {
 <script src="https://cdnjs.cloudflare.com/ajax/libs/jqueryui/1.12.1/jquery-ui.min.js" integrity="sha256-KM512VNnjElC30ehFwehXjx1YCHPiQkOPmqnrWtpccM=" crossorigin="anonymous" defer></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/tinyscrollbar/2.4.2/jquery.tinyscrollbar.min.js" integrity="sha256-gENsdwXJl1qiwOqS0DF+kfqTP5Dy+0gDTtxpRcWVhrU=" crossorigin="anonymous" defer></script>
 
-<script src="https://cdnjs.cloudflare.com/ajax/libs/video.js/7.3.0/video.min.js" integrity="sha256-FtN3AlYCFtRDFdQIG+XM7JgkF3CYyzDkysTR34GUII4=" crossorigin="anonymous" defer></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/video.js/7.14.3/video.min.js" integrity="sha512-kNY62HZwz6DRXwF3PP9ltv2db/E+pC9VA8CdDuABXycPlb0IxhOyUprvdkx6cKdKeG5nf+rP7t2XW7unXig6JQ==" crossorigin="anonymous" referrerpolicy="no-referrer" defer></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/videojs-flash/2.1.2/videojs-flash.min.js" integrity="sha256-2sKPIPOV8Cj34r74ZnRcdKrQ7Jqqg0o1zR2c74VDW1s=" crossorigin="anonymous" defer></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/dashjs/2.9.2/dash.all.min.js" integrity="sha256-EmXFhpSryXnCa3tOiKDfYUFhpmnkvo3PSe3Tj3KpX6o=" crossorigin="anonymous" defer></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/videojs-contrib-dash/2.10.0/videojs-dash.min.js" integrity="sha256-xhLRr5mlvCCC7DndQjNURZOXGxwYUoB2VoF0mNUiuJc=" crossorigin="anonymous" defer></script>

--- a/web/js/player.js
+++ b/web/js/player.js
@@ -543,11 +543,7 @@ window.PLAYERS.file = {
 		}
 
         $("#ytapiplayer").append(player);
-		const videoJsPlayer = videojs("vjs_player", {
-            userActions: {
-				hotkeys: false
-			}
-        });
+		const videoJsPlayer = videojs("vjs_player");
 
 		videoJsPlayer.ready(function(){
 			this.volume(volume);

--- a/web/js/player.js
+++ b/web/js/player.js
@@ -543,7 +543,11 @@ window.PLAYERS.file = {
 		}
 
         $("#ytapiplayer").append(player);
-		const videoJsPlayer = videojs("vjs_player");
+		const videoJsPlayer = videojs("vjs_player", {
+            userActions: {
+				hotkeys: false
+			}
+        });
 
 		videoJsPlayer.ready(function(){
 			this.volume(volume);


### PR DESCRIPTION
Update video.js to latest stable to fix the spacebar being stuck. The errors that #40 gave were pointing to video.js, and not even disabling keyboard controls worked, so updated lib it is. From my limited testing there were no breaking changes.

After searching the video.js releases the bug was probably fixed in this release https://github.com/videojs/video.js/releases/tag/v7.5.0

Fixes #40 