### PR TITLE
Prevent possible double firing of callback

### DIFF
--- a/web/js/lib.js
+++ b/web/js/lib.js
@@ -62,16 +62,13 @@
 					$(btn).children("span").text(origText);
 				});
 			};
-			$(btn).dblclick(function(){
-				if(callback)callback();
-				btn.revert();
-			});
 			$(btn).click(function(){
 				if($(btn).hasClass("confirm")){
-					$(btn).dblclick();
+					if(callback)callback();
+					btn.revert();
 				} else {
 					$(btn).data("w",$(btn).width());
-					$(btn).addClass("confirm",200,function(){
+					$(btn).addClass("confirm",50,function(){
 						$(btn).width($(btn).data("w"));
 						$(btn).children("span").text("Really?");
 						setTimeout(function(){


### PR DESCRIPTION
Removed the listener for the double click and moved its contents to normal click listener. Also reduced the duration on addClass to make it easier to doubleclick

It was possible to fire two doubleclick events causing the callback being called twice. This was most noticeable on playlist jumping which sent two `forceVideoChange` events. 

From my own testings this completely fixes the skip bug, fixes #4  
