### PR TITLE
Twitchclip: Updated regexes to include '-'

### DIFF
--- a/web/js/functions.js
+++ b/web/js/functions.js
@@ -2228,8 +2228,8 @@ function parseVideoURL(url, callback) {
 	var m = url.match(new RegExp("i\\.ytimg\\.com/an_webp/([a-zA-Z0-9_-]{11})/")); if (m) { callback(m[1], "yt"); return; }
 	var m = url.match(new RegExp("dailymotion.com/(?:embed/)?video/([a-zA-Z0-9]+)")); if (m) { callback(m[1], "dm"); return; }
 	var m = url.match(new RegExp("dai.ly/([a-zA-Z0-9]+)")); if (m) { callback(m[1], "dm"); return; }
-	var m = url.match(new RegExp("clips\\.twitch\\.tv/([A-Za-z0-9]+)")); if (m) { callback(m[1], "twitchclip", m[1]); return; }
-	var m = url.match(new RegExp("twitch\\.tv/[A-Za-z0-9]+/clip/([A-Za-z0-9]+)")); if (m) { callback(m[1], "twitchclip", m[1]); return; }
+	var m = url.match(new RegExp("clips\\.twitch\\.tv/([A-Za-z0-9-]+)")); if (m) { callback(m[1], "twitchclip", m[1]); return; }
+	var m = url.match(new RegExp("twitch\\.tv/[A-Za-z0-9]+/clip/([A-Za-z0-9-]+)")); if (m) { callback(m[1], "twitchclip", m[1]); return; }
 	var m = url.match(new RegExp("twitch\\.tv/((?:videos/)?[A-Za-z0-9]+)")); if (m) { callback(m[1], "twitch", m[1]); return; }
 	var m = url.match(new RegExp("^rtmp://")); if (m) { callback(url, "osmf", "~ Raw Livestream ~"); return; }
 	var m = url.match(new RegExp("\\.f4m$")); if (m) { callback(url, "osmf", "~ Raw Livestream ~"); return; }


### PR DESCRIPTION
At somepoint Twitch decided to include '-' as part of their clip id's. Updated regex to include those too.

Tested with
[https://www.twitch.tv/quickybaby/clip/CulturedBitterPuppyCharlieBitMe-coqkwwyNlmUnrpoP](https://www.twitch.tv/quickybaby/clip/CulturedBitterPuppyCharlieBitMe-coqkwwyNlmUnrpoP)
and
[https://clips.twitch.tv/TenuousStrangeBaguettePrimeMe-uCoo8gMOAHuA1TOS](https://clips.twitch.tv/TenuousStrangeBaguettePrimeMe-uCoo8gMOAHuA1TOS)