### PR TITLE
Fix video skip and refactor/optimize video deletion

### DIFF
--- a/docker/node/server.js
+++ b/docker/node/server.js
@@ -2612,9 +2612,12 @@ io.sockets.on('connection', function (ioSocket) {
 
 		//switch before actually deleting the correct video
 		if (video.node === SERVER.ACTIVE) {
-			playNext();
-		}
+			SERVER.ACTIVE = SERVER.ACTIVE.next;
 
+			handleNewVideoChange();
+			sendStatus("forceVideoChange", io.sockets);
+		}
+		
 		delVideo(video, data.sanityid, socket);
 	});
 	socket.on("addVideo", function (data) {

--- a/docker/node/server.js
+++ b/docker/node/server.js
@@ -2576,12 +2576,17 @@ io.sockets.on('connection', function (ioSocket) {
 			video = video.next;
 		}
 
-		if ('colorTagVolat' in prev.node.meta) {
-			_setVideoColorTag(prev.node, prev.position, false, false);
+		//check if we actually got both
+		if (!next || !prev) {
+			return doorStuck();
 		}
 
 		if (data.sanityid && next.node.videoid !== data.sanityid) {
 			return doorStuck();
+		}
+
+		if ('colorTagVolat' in prev.node.meta) {
+			_setVideoColorTag(prev.node, prev.position, false, false);
 		}
 	
 		SERVER.ACTIVE = next.node;

--- a/docker/node/server.js
+++ b/docker/node/server.js
@@ -469,7 +469,7 @@ function playNext() {
 
 	SERVER.ACTIVE = SERVER.ACTIVE.next;
 
-	if ('colorTagVolat' in active.node.meta) {
+	if (!active.node.volat && 'colorTagVolat' in active.node.meta) {
 		_setVideoColorTag(active.node, active.position, false, false);
 	}
 
@@ -2585,7 +2585,7 @@ io.sockets.on('connection', function (ioSocket) {
 			return doorStuck(socket);
 		}
 
-		if ('colorTagVolat' in prev.node.meta) {
+		if (!prev.node.volat && 'colorTagVolat' in prev.node.meta) {
 			_setVideoColorTag(prev.node, prev.position, false, false);
 		}
 	

--- a/docker/node/server.js
+++ b/docker/node/server.js
@@ -2578,11 +2578,11 @@ io.sockets.on('connection', function (ioSocket) {
 
 		//check if we actually got both
 		if (!next || !prev) {
-			return doorStuck();
+			return doorStuck(socket);
 		}
 
 		if (data.sanityid && next.node.videoid !== data.sanityid) {
-			return doorStuck();
+			return doorStuck(socket);
 		}
 
 		if ('colorTagVolat' in prev.node.meta) {

--- a/docker/node/server.js
+++ b/docker/node/server.js
@@ -2608,7 +2608,14 @@ io.sockets.on('connection', function (ioSocket) {
 			return;
 		}
 
-		delVideo(getVideoAt(data.index), data.sanityid, socket);
+		const video = getVideoAt(data.index);
+
+		//switch before actually deleting the correct video
+		if (video.node === SERVER.ACTIVE) {
+			playNext();
+		}
+
+		delVideo(video, data.sanityid, socket);
 	});
 	socket.on("addVideo", function (data) {
 		if (!authService.can(socket.session, actions.ACTION_CONTROL_PLAYLIST)) {

--- a/docker/node/server.js
+++ b/docker/node/server.js
@@ -2610,6 +2610,10 @@ io.sockets.on('connection', function (ioSocket) {
 
 		const video = getVideoAt(data.index);
 
+		if (video.node.videoid !== data.sanityid) {
+			return doorStuck(socket);
+		}
+
 		//switch before actually deleting the correct video
 		if (video.node === SERVER.ACTIVE) {
 			SERVER.ACTIVE = SERVER.ACTIVE.next;


### PR DESCRIPTION
The double removal was caused when mod or berry forced the video change and current video was volatile. The video was changed in two places, first in forceVideoChange socket handler and inside delVideo() through playNext(). Now the change only happens in forceVideoChange handler.

I also removed bunch of unnecessary iterations of the playlist, by carrying both index and video/node from the socket events instead of iterating again and again.

Tested forced video changes from perma -> volatile, volatile -> perma, volatile->volatile. Also tested normal progression.