### PR TITLE
Grab context from outside of the callback function

### DIFF
--- a/docker/node/modules/database/service.js
+++ b/docker/node/modules/database/service.js
@@ -26,15 +26,16 @@ exports.DatabaseService = class extends ServiceBase {
 			password: config.mysql_pass,
 		});
 
+		let self = this;
 		this.connection.on("error", function(err) {
-			this.log.error(
+			self.log.error(
 				events.EVENT_DB_CONNECTION,
 				"the database connection threw an error: attempting reconnect",
 				{},
 				err,
 			);
 			setTimeout(function() {
-				this.init();
+				self.init();
 			}, 1000);
 		});
 


### PR DESCRIPTION
If the database connection would return an error for some reason, the process would panic as it would not find log in the functions context and whole server would restart when callback attempted to log the error and restart the connection.