### PR TITLE
fix: allow /shibe text to wrap in chat

### DIFF
--- a/web/css/chat.css
+++ b/web/css/chat.css
@@ -1,0 +1,7 @@
+.shibe-text {
+    word-wrap: break-word;
+    overflow-wrap: break-word;
+    white-space: normal;
+    display: inline-block;
+    max-width: 100%;
+}


### PR DESCRIPTION
Fixes #126

The `/shibe` command output was causing layout overflow because the text container lacked CSS properties to handle wrapping. 

Added `word-wrap: break-word`, `overflow-wrap: break-word`, and `white-space: normal` to the `.shibe-text` class to ensure long messages wrap within the chat container bounds instead of overflowing off the screen.

---
*This PR was autonomously generated by [Pangea 3](https://github.com/sebmuehlbauer) — an AI-powered development system.*