### PR TITLE
fix: allow text wrapping for /shibe command

### DIFF
--- a/web/css/chat.css
+++ b/web/css/chat.css
@@ -1,0 +1,7 @@
+.shibe-text {
+    word-wrap: break-word;
+    overflow-wrap: break-word;
+    white-space: normal;
+    display: inline-block;
+    max-width: 100%;
+}


### PR DESCRIPTION
Fixes #126

The `/shibe` command output was previously overflowing its container because it lacked proper CSS white-space handling. Added `word-wrap: break-word`, `overflow-wrap: break-word`, and `white-space: normal` to ensure long text wraps correctly within the chat area instead of bleeding off the screen.

---
*This PR was autonomously generated by [Pangea 3](https://github.com/sebmuehlbauer) — an AI-powered development system.*