### PR TITLE
Stop Socket.IO disconnect loop

### DIFF
--- a/web/js/init.js
+++ b/web/js/init.js
@@ -230,16 +230,19 @@ try {
 		'reconnection delay': 500 + Math.random() * 1000,
 		'reopen delay': 500 + Math.random() * 1000,
 		'max reconnection attempts': 10,
-        'transports': ['websocket']
+		'transports': ['websocket']
 	});
 
 	window.socket.on('error', function (reason) {
 		if (reason == "handshake error") {
 			window.location = "ban.php";
-		} else {
+		} else if (typeof reason === 'string') {
 			$(function () {
 				var AWSHIT = $("<center><h1>Unable to connect Socket.IO: " + reason + "</h1></center>").prependTo(document.body);
 			});
+			console.error(reason);
+		} else {
+			// websocket drop, reconnect handles it
 			console.error(reason);
 		}
 	});
@@ -1280,7 +1283,7 @@ function initPlaylistControls(plwrap) {
 						queue:false,
 						videotype:type,
 						videoid:id,
-                        videotitle:videotitle,
+						videotitle:videotitle,
 						volat:false
 					};
 					socket.emit("addVideo", LAST_QUEUE_ATTEMPT);

--- a/web/js/initvote.js
+++ b/web/js/initvote.js
@@ -230,16 +230,18 @@ try {
 		'reconnection delay': 500 + Math.random() * 1000,
 		'reopen delay': 500 + Math.random() * 1000,
 		'max reconnection attempts': 10,
-        'transports': ['websocket']
+		'transports': ['websocket']
 	});
 
 	window.socket.on('error', function (reason) {
 		if (reason == "handshake error") {
 			window.location = "ban.php";
-		} else {
+		} else if (typeof reason === 'string') {
 			$(function () {
 				var AWSHIT = $("<center><h1>Unable to connect Socket.IO: " + reason + "</h1></center>").prependTo(document.body);
 			});
+			console.error(reason);
+		} else {
 			console.error(reason);
 		}
 	});


### PR DESCRIPTION
Socket.IO 0.9 fires the error event with a raw Event object when the websocket connection drops. The old handler did string concat with it, producing "Unable to connect Socket.IO: [object Event]" and prepending a new banner every time. Since the socket reconnects automatically, these don't need a banner at all.

Only show the banner when reason is an actual string (server errors like "handshake error"). Log everything else to console.